### PR TITLE
Suggested enhancement for issue #95

### DIFF
--- a/etc/k8s/helm/Chart.yaml
+++ b/etc/k8s/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: itb
-version: 1.3.0
+version: 1.3.1
 description: A Helm chart to install the Interoperability Test Bed (ITB) on Kubernetes
 type: application
 keywords:

--- a/etc/k8s/helm/templates/NOTES.txt
+++ b/etc/k8s/helm/templates/NOTES.txt
@@ -11,7 +11,7 @@ The Interoperability Test Bed (ITB) is now deployed on your cluster (release {{ 
 To access the ITB's user interface from outside your cluster you must ensure an ingress controller is available
 (e.g. https://kubernetes.github.io/ingress-nginx/). With an ingress in place the ITB is available at:
 
-  {{ .Values.ui.env.TESTBED_HOME_LINK }}
+  {{ include "ui.homeLink" . }}
 
 In case this is a new ITB installation, you will find the credentials of
 the default administrator account (admin@itb) logged in the output of the
@@ -25,7 +25,8 @@ To find out more and see how to use your new ITB instance please refer to:
 
 For questions and support please open a ticket on GitHub ({{ with index .Chart.Sources 0 }}{{ . }}{{ end }}), 
 or send an email to DIGIT-ITB@ec.europa.eu.
-{{ if ne .Values.ui.env.TESTBED_MODE "PRODUCTION" }}
+{{- if or (not .Values.ui.env) (ne .Values.ui.env.TESTBED_MODE "PRODUCTION") }}
+
 IMPORTANT: Your ITB instance is configured as a development instance. 
 To define an instance suitable for production please refer to the ITB's
 production installation guide:

--- a/etc/k8s/helm/templates/_helpers.tpl
+++ b/etc/k8s/helm/templates/_helpers.tpl
@@ -139,8 +139,82 @@ Return the name to use for the file repository persistent volume.
 {{- end }}
 
 {{/*
+Return the ingress path to use for itb-ui.
+*/}}
+{{- define "ingress.uiPath" }}
+{{- .Values.ingress.path.ui | default "/itb" -}}
+{{- end }}
+
+{{/*
+Return the ingress path to use for itb-srv.
+*/}}
+{{- define "ingress.srvPath" }}
+{{- .Values.ingress.path.srv | default "/itbsrv" -}}
+{{- end }}
+
+{{/*
 Return the context path to use for itb-ui.
 */}}
 {{- define "ui.contextRoot" }}
-{{- .Values.ui.env.WEB_CONTEXT_ROOT | default "/" -}}
+{{- $path := include "ingress.uiPath" . -}}
+{{- if and .Values.ui .Values.ui.env }}
+  {{- .Values.ui.env.WEB_CONTEXT_ROOT | default (include "ingress.uiPath" .) -}}
+{{- end }}
+{{- $path -}}
+{{- end }}
+
+{{/*
+Return the context path to use for itb-srv.
+*/}}
+{{- define "srv.contextRoot" }}
+{{- $path := include "ingress.srvPath" . -}}
+{{- if and .Values.srv .Values.srv.env }}
+  {{- $path = index .Values.srv.env "server.servlet.context-path" | default (include "ingress.srvPath" .) }}
+{{- end }}
+{{- $path -}}
+{{- end }}
+
+{{/*
+Return the authentication cookie path to use for itb-ui.
+*/}}
+{{- define "ui.authenticationCookiePath" }}
+{{- include "ingress.uiPath" . -}}
+{{- end }}
+
+{{/*
+Return the home link to use for itb-ui.
+*/}}
+{{- define "ui.homeLink" -}}
+{{- $tlsHost := "" -}}
+{{- $tlsSecret := "" -}}
+{{- if .Values.ingress.tls }}
+  {{- $tlsHost = .Values.ingress.tls.host | default "" -}}
+  {{- $tlsSecret = .Values.ingress.tls.secretName | default "" -}}
+{{- end }}
+{{- $scheme := "http" -}}
+{{- if and $tlsHost $tlsSecret }}
+  {{- $scheme = "https" }}
+{{- end }}
+{{- $host := $tlsHost | default "localhost" -}}
+{{- $path := (include "ingress.uiPath" .) -}}
+{{- printf "%s://%s%s" $scheme $host $path -}}
+{{- end }}
+
+{{/*
+Return the callback root URL to use for itb-srv.
+*/}}
+{{- define "srv.callbackRoot" -}}
+{{- $tlsHost := "" -}}
+{{- $tlsSecret := "" -}}
+{{- if .Values.ingress.tls }}
+  {{- $tlsHost = .Values.ingress.tls.host | default "" -}}
+  {{- $tlsSecret = .Values.ingress.tls.secretName | default "" -}}
+{{- end }}
+{{- $scheme := "http" -}}
+{{- if and $tlsHost $tlsSecret }}
+  {{- $scheme = "https" }}
+{{- end }}
+{{- $host := $tlsHost | default "localhost" -}}
+{{- $path := (include "ingress.srvPath" .) -}}
+{{- printf "%s://%s%s" $scheme $host $path -}}
 {{- end }}

--- a/etc/k8s/helm/templates/ingress.yaml
+++ b/etc/k8s/helm/templates/ingress.yaml
@@ -12,7 +12,7 @@ spec:
   {{- if .Values.ingress.class }}
   ingressClassName: {{ .Values.ingress.class }}
   {{- end }}
-  {{- if and .Values.ingress.tls.host .Values.ingress.tls.secretName }}
+  {{- if and .Values.ingress.tls .Values.ingress.tls.host .Values.ingress.tls.secretName }}
   tls:
     - hosts:
         - {{ .Values.ingress.tls.host }}
@@ -21,14 +21,14 @@ spec:
   rules:
     - http:
         paths:
-          - path: {{ .Values.ingress.path.srv }}
+          - path: {{ include "ingress.srvPath" . | quote }}
             pathType: Prefix
             backend:
               service:
                 name: {{ include "srv.serviceName" . }}
                 port:
                   number: {{ include "srv.servicePort" . }}
-          - path: {{ .Values.ingress.path.ui }}
+          - path: {{ include "ingress.uiPath" . | quote }}
             pathType: Prefix
             backend:
               service:

--- a/etc/k8s/helm/templates/ingress.yaml
+++ b/etc/k8s/helm/templates/ingress.yaml
@@ -21,14 +21,14 @@ spec:
   rules:
     - http:
         paths:
-          - path: /itbsrv
+          - path: {{ .Values.ingress.path.srv }}
             pathType: Prefix
             backend:
               service:
                 name: {{ include "srv.serviceName" . }}
                 port:
                   number: {{ include "srv.servicePort" . }}
-          - path: /itb
+          - path: {{ .Values.ingress.path.ui }}
             pathType: Prefix
             backend:
               service:

--- a/etc/k8s/helm/templates/srv-deployment.yaml
+++ b/etc/k8s/helm/templates/srv-deployment.yaml
@@ -17,10 +17,20 @@ spec:
         - image: {{ .Values.srv.image | quote }}
           imagePullPolicy: {{ .Values.srv.imagePullPolicy | default "IfNotPresent" | quote }}
           name: {{ include "srv.name" . }}
-          {{- if .Values.srv.env }}
           env:
+          {{- if or (not .Values.srv.env) (not (index .Values.srv.env "server.servlet.context-path")) }}
+            - name: server.servlet.context-path
+              value: {{ include "srv.contextRoot" . | quote }}
+          {{- end }}
+          {{- if or (not .Values.srv.env) (not .Values.srv.env.CALLBACK_ROOT_URL) }}
+            - name: CALLBACK_ROOT_URL
+              value: {{ include "srv.callbackRoot" . | quote }}
+          {{- end }}
+          {{- if or (not .Values.srv.env) (not .Values.srv.env.REPOSITORY_ROOT_URL) }}
             - name: REPOSITORY_ROOT_URL
               value: "http://{{ include "ui.serviceName" . }}:{{ include "ui.servicePort" . }}{{ include "ui.contextRoot" . }}"
+          {{- end }}
+          {{- if .Values.srv.env }}
           {{- range $key, $value := .Values.srv.env }}
             - name: {{ $key }}
               value: {{ $value | quote }}

--- a/etc/k8s/helm/templates/ui-deployment.yaml
+++ b/etc/k8s/helm/templates/ui-deployment.yaml
@@ -19,17 +19,29 @@ spec:
           name: {{ include "ui.name" . }}
           env:
             - name: TESTBED_SERVICE_URL
-              value: "http://{{ include "srv.serviceName" . }}:{{ include "srv.servicePort" . }}/itbsrv/TestbedService"
+              value: "http://{{ include "srv.serviceName" . }}:{{ include "srv.servicePort" . }}{{ include "srv.contextRoot" . }}/TestbedService"
             - name: TESTBED_CLIENT_URL_INTERNAL
-              value: "http://0.0.0.0:{{ include "ui.callbackPort" . }}/TestbedClient"
+              value: "http://0.0.0.0:{{ include "ui.callbackPort" . }}{{ include "ui.contextRoot" . }}/TestbedClient"
             - name: TESTBED_CLIENT_URL
-              value: "http://{{ include "ui.serviceName" . }}:{{ include "ui.serviceCallbackPort" . }}/TestbedClient"
+              value: "http://{{ include "ui.serviceName" . }}:{{ include "ui.serviceCallbackPort" . }}{{ include "ui.contextRoot" . }}/TestbedClient"
             - name: DB_DEFAULT_URL
               value: "jdbc:mysql://{{ include "mysql.serviceName" . }}:{{ include "mysql.servicePort" . }}/gitb?characterEncoding=UTF-8&useUnicode=true&autoReconnect=true&useSSL=false&verifyServerCertificate=false&allowPublicKeyRetrieval=true"
             - name: DB_DEFAULT_ROOTURL
               value: "jdbc:mysql://{{ include "mysql.serviceName" . }}:{{ include "mysql.servicePort" . }}/"
             - name: REDIS_HOST
               value: {{ include "redis.serviceName" . | quote }}
+          {{- if or (not .Values.ui.env) (not .Values.ui.env.WEB_CONTEXT_ROOT) }}
+            - name: WEB_CONTEXT_ROOT
+              value: {{ include "ui.contextRoot" . | quote }}
+          {{- end }}
+          {{- if or (not .Values.ui.env) (not .Values.ui.env.AUTHENTICATION_COOKIE_PATH) }}
+            - name: AUTHENTICATION_COOKIE_PATH
+              value: {{ include "ui.authenticationCookiePath" . | quote }}
+          {{- end }}
+          {{- if or (not .Values.ui.env) (not .Values.ui.env.TESTBED_HOME_LINK) }}
+            - name: TESTBED_HOME_LINK
+              value: {{ include "ui.homeLink" . | quote }}
+          {{- end }}
           {{- if .Values.ui.env }}
           {{- range $key, $value := .Values.ui.env }}
             - name: {{ $key }}

--- a/etc/k8s/helm/values.yaml
+++ b/etc/k8s/helm/values.yaml
@@ -125,8 +125,12 @@ srv:
     #
     # Environment variables (listed with their defaults).
     #
-    # srv.env.CALLBACK_ROOT_URL is the root URL for callbacks originating from external test services or built-in messaging handlers.
-    CALLBACK_ROOT_URL: https://localhost/itbsrv
+    ## srv.env.CALLBACK_ROOT_URL is the root URL for callbacks originating from external test services or built-in messaging handlers.
+    ## By default, this is set to SCHEME://HOST/PATH where
+    ## - SCHEME is "https" if ingress.tls.host and ingress.tls.secretName are set, or "http" otherwise.
+    ## - HOST matches ingress.tls.host if set, or "localhost" otherwise.
+    ## - /PATH matches ingress.srv.path.
+    # CALLBACK_ROOT_URL: https://localhost/itbsrv
     #
     ## srv.env.HMAC_KEY is the key to use to secure exchanges between itb-ui and itb-srv.
     ## The value set here must match the value set for "ui.env.HMAC_KEY".
@@ -177,17 +181,26 @@ ui:
     #
     # Environment variables (listed with their defaults).
     #
-    # ui.env.TESTBED_HOME_LINK is the external root URL at which the user interface can be accessed by external users.
-    TESTBED_HOME_LINK: https://localhost/itb
+    ## ui.env.TESTBED_HOME_LINK is the external root URL at which the user interface can be accessed by external users.
+    ## The value of this variable would need to be adapted depending on your ingress configuration, unless you use a
+    ## separate reverse proxy to publicly expose the itb-ui component. If this is not the case, this value would be
+    ## affected by the ingress TLS configuration (ingress.lts.host) and path mapping (ingress.path.ui).
+    ## By default, this is set to SCHEME://HOST/PATH where:
+    ## - SCHEME is "https" if ingress.tls.host and ingress.tls.secretName are set, or "http" otherwise.
+    ## - HOST matches ingress.tls.host if set, or "localhost" otherwise.
+    ## - /PATH matches ingress.ui.path.
+    # TESTBED_HOME_LINK: https://localhost/itb
     #
-    # ui.env.AUTHENTICATION_COOKIE_PATH is the path to which user cookies should be bound, matching the public access path following the host name and port.
-    # In case via ingress or another proxy, the interface is accessible at e.g. https://localhost/itb, you must set ui.env.AUTHENTICATION_COOKIE_PATH to the defined path (e.g. "/itb").
-    AUTHENTICATION_COOKIE_PATH: /itb
+    ## ui.env.AUTHENTICATION_COOKIE_PATH is the path to which user cookies should be bound, matching the public access path following the host name and port.
+    ## In case via ingress or another proxy, the interface is accessible at e.g. https://localhost/itb, you must set ui.env.AUTHENTICATION_COOKIE_PATH to the defined path (e.g. "/itb").
+    ## Note that if you publicly access the itb-ui component based on the ingress' path mapping (set via ingress.path.ui), this variable would need to be set with the same value.
+    ## By default, this is set to the value of ingress.path.ui.
+    # AUTHENTICATION_COOKIE_PATH: /itb
     #
-    # ui.env.WEB_CONTEXT_ROOT is the web application context root at which the itb-ui application will be bound to. This could
-    # differ from ui.env.AUTHENTICATION_COOKIE_PATH (the public path), but in practice k8s ingress configuration is simplified
-    # if they match.
-    WEB_CONTEXT_ROOT: /itb
+    ## ui.env.WEB_CONTEXT_ROOT is the web application context root at which the itb-ui application will be bound to. This could
+    ## differ from ui.env.AUTHENTICATION_COOKIE_PATH (the public path), but in practice k8s ingress configuration is simplified
+    ## if they match. By default, this is set to the value of ingress.path.ui.
+    # WEB_CONTEXT_ROOT: /itb
     #
     ## ui.env.TESTBED_MODE is the mode ("production" or "development") in which the ITB is running. 
     ## When switching to "production" you will need to set sensitive values as described in https://www.itb.ec.europa.eu/docs/guides/latest/installingTheTestBedProduction/index.html#step-3-prepare-basic-configuration
@@ -225,22 +238,52 @@ ingress:
   # ingress.name is the name of the ITB ingress resource defined in the cluster.
   name: itb-ingress
   #
-  ## ingress.class is the name of the ingress controller class. You can view your cluster's available ingress
-  ## classes (and the names used to refer to them) by issuing "kubectl get ingressclass". You may also omit
-  ## this if you have a default ingress class configured.
-  ## The default class considered is "nginx" (see https://kubernetes.github.io/ingress-nginx/) but this
-  ## can be replaced for different ingress implementations.
+  # ingress.class is the name of the ingress controller class. You can view your cluster's available ingress
+  # classes (and the names used to refer to them) by issuing "kubectl get ingressclass". You may also omit
+  # this if you have a default ingress class configured.
+  # The default class considered is "nginx" (see https://kubernetes.github.io/ingress-nginx/) but this
+  # can be replaced for different ingress implementations.
   class: nginx
   #
   # Configuration specific to TLS settings.
   #
+  # To expose your Test Bed instance via HTTP (e.g. for development purposes), you can set ingress.tls as empty in your
+  # override value file:
+  #
+  # ingress:
+  #    tls:
+  #
+  # If set as such, the itb-ui and itb-srv components will be accessible over HTTP, with this being automatically reflected
+  # in related configuration properties such as ui.env.TESTBED_HOME_LINK and srv.env.CALLBACK_ROOT_URL.
   tls:
     #
-    ## ingress.tls.host is the complete host name to use by the ingress when generating a server certificate for TLS.
+    # ingress.tls.host is the complete host name to use by the ingress when generating a server certificate for TLS.
     host: localhost
     #
-    ## ingress.tls.secretName is the name of the secret corresponding to the server certificate to use for TLS.
+    # ingress.tls.secretName is the name of the secret corresponding to the server certificate to use for TLS.
     secretName: itb-tls-secret
+  #
+  # Ingress path mappings.
+  #
+  path:
+    #
+    # ingress.path.ui is the path at which the ingress will expose access to the itb-ui service from outside the cluster.
+    # In case this ingress path represents how users would publicly access the itb-ui frontend, you will need to also
+    # ensure that the environment variables AUTHENTICATION_COOKIE_PATH (set via ui.env.AUTHENTICATION_COOKIE_PATH) and
+    # TESTBED_HOME_LINK (set via ui.env.TESTBED_HOME_LINK) are set accordingly. These are both set by default to consider
+    # the value of ingress.path.ui, but may differ if for example you have a separate reverse proxy that forward requests
+    # to the ingress but exposes the Test Bed's components at different paths.
+    # Note also that the web context root of itb-ui, set via ui.env.WEB_CONTEXT_ROOT, is also set by default to the value
+    # of ingress.path.ui as the ingress configuration is simpler when public and internal path mappings match. Such a
+    # match is however, not mandatory but would require a corresponding change in the ingress configuration (in ingress.yaml).
+    ui: "/itb"
+    #
+    # ingress.path.srv is the path at which the ingress will expose access to the itb-srv service from outside the cluster.
+    # In case this ingress path represents how test services and systems-under-test access the test engine publicly,
+    # ensure that environment variable CALLBACK_ROOT_URL (set via srv.env.CALLBACK_ROOT_URL) is set accordingly. This
+    # considers by default the value of ingress.path.srv, but may differ if for example you have a separate reverse proxy
+    # that forward requests to the ingress but exposes the Test Bed's components at different paths.
+    srv: "/itbsrv"
   #
   # Ingress annotations.
   #


### PR DESCRIPTION
It is a suggested enhancement for issue #95 

Using this template it is possible to add more configuration options like the following example
```
ingress:
  name: itb-ingress
  class: nginx
  tls:
    host: itb.myhost.com
    secretName: itb-tls-secret
  path:
    ui: "/"
    srv: "/itbsrv"
  annotations:
    acme.cert-manager.io/http01-edit-in-place: "true"
    cert-manager.io/cluster-issuer: "my-prod"
```